### PR TITLE
More flexibility in error_handling extension

### DIFF
--- a/lib/hobbit/error_handling.rb
+++ b/lib/hobbit/error_handling.rb
@@ -12,9 +12,11 @@ module Hobbit
 
     def _call(env)
       super
-    rescue Exception => e
-      body = instance_eval { self.class.errors[e.class].call(e) }
-      response.body = [body] if self.class.errors.include? e.class
+    rescue *self.class.errors.keys => e
+      rescued = self.class.errors.keys.detect { |k| e.kind_of?(k)}
+
+      body = instance_eval { self.class.errors[rescued].call(e) }
+      response.body = [body]
       response.finish
     end
 


### PR DESCRIPTION
Only rescue defined exception classes, unhandled exceptios are left intact. Allow to rescue a descendant class exception by the definition of a rescue block for ancestor class.
