### PR TITLE
Pass render locals/opts to template engine

### DIFF
--- a/lib/hobbit/render.rb
+++ b/lib/hobbit/render.rb
@@ -26,9 +26,9 @@ module Hobbit
         layout = options.delete :layout
       end
       if layout
-        _render(layout) { _render(template) }
+        _render(layout, locals, options) { _render(template, locals, options) }
       else
-        _render template
+        _render template, locals, options
       end
     end
 


### PR DESCRIPTION
The current Hobbit::Render#render method accepts arguments for locals
and options, but doesn't pass these down to the actual private _render
call. In the case of locals, the value is lost entirely and never used
anywhere. This modifies the calls to _render to forward those values to
the templater.
