### PR TITLE
fix impossible to set Content-Type header when using Hobbit::Filter

### DIFF
--- a/lib/hobbit/filter.rb
+++ b/lib/hobbit/filter.rb
@@ -28,7 +28,8 @@ module Hobbit
       env['PATH_INFO'] = '/' if env['PATH_INFO'].empty?
       @env = env
       @request = Rack::Request.new(@env)
-      @response = Hobbit::Response.new
+      @response = Hobbit::Response.new([], 200, {}) # pass empty params so that Content-Type header remains unset. otherwise, the main response's Content-Type will be ignored.
+      #@response.headers.delete "Content-Type" #another way to undo overriding default content-type
       catch :halt do
         filter :before
         unless @response.status == 302

--- a/lib/hobbit/render.rb
+++ b/lib/hobbit/render.rb
@@ -40,8 +40,8 @@ module Hobbit
       'views'
     end
 
-    def clear_cache
-      Thread.current[:cache] = nil
+    def clear_template_render_cache
+      Thread.current[:hobbit_render_cache] = nil
     end
     
     private
@@ -53,7 +53,7 @@ module Hobbit
     end
 
     def cache
-      Thread.current[:cache] ||= Tilt::Cache.new
+      Thread.current[:hobbit_render_cache] ||= Tilt::Cache.new
     end
   end
 end

--- a/lib/hobbit/render.rb
+++ b/lib/hobbit/render.rb
@@ -40,6 +40,10 @@ module Hobbit
       'views'
     end
 
+    def clear_cache
+      Thread.current[:cache] = nil
+    end
+    
     private
 
     def _render(template, locals = {}, options = {}, &block)


### PR DESCRIPTION
when using Hobbit::Filter, the Content-Type header is ignored because it gets overwritten by the default "text/html; charset=utf-8" Content-Type header used in the :before filter.
