### PR TITLE
Added missing require lines for mote and tilt rendering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This module provides rendering to your hobbit application using [mote](https://g
 To use this extension just include the module:
 
 ```ruby
+require 'mote'
 require 'hobbit'
 require 'hobbit/contrib'
 
@@ -186,10 +187,12 @@ NOTE: Use `{{content}}` within your layout to yield the rendered page.
 
 ### Hobbit::Render
 
-This module provides rendering to your hobbit application. To use this
-extension just include the module:
+This module provides rendering to your hobbit application using
+[tilt](https://github.com/rtomayko/tilt). To use this extension just include
+the module:
 
 ```ruby
+require 'tilt'
 require 'hobbit'
 require 'hobbit/contrib'
 


### PR DESCRIPTION
Hey @patriciomacadden,

This PR fixes https://github.com/patriciomacadden/hobbit-contrib/issues/15

I believe that the example should also have the lines that require `mote` and `tilt` before requiring `hobbit/contrib`

Please check it out and let me know!

Thanks
